### PR TITLE
chore: remove vscode-typescript-vue-plugin

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["Vue.volar", "Vue.vscode-typescript-vue-plugin"]
+  "recommendations": ["Vue.volar"]
 }


### PR DESCRIPTION
Just saw this when testing the theme-starter.

BTW thanks for creating formkit, its such a joy!